### PR TITLE
Uncompiled Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,17 @@ The Spring Auto-reconfiguration Buildpack is a Cloud Native Buildpack V3 that pr
 ## Detection
 The detection phase passes if:
 
-* A `spring-core` jar exists in the application
+* The build plan contains `jvm-application`
   * Contributes `auto-reconfiguration` to the build plan
 
 ## Build
 If the build plan contains
 
 * `auto-reconfiguration`
-  * Contributes the Spring Auto-reconfiguration jar to a layer marked launch.
-  * Adds the Spring Auto-reconfiguration jar to the classpath.
+  * Checks for the existence of a `spring-core` jar in the application.
+  * If found,
+    * Contributes the Spring Auto-reconfiguration jar to a layer marked launch.
+    * Adds the Spring Auto-reconfiguration jar to the classpath.
 
 ## License
 This buildpack is released under version 2.0 of the [Apache License][a].

--- a/autoreconfiguration/autoreconfiguration.go
+++ b/autoreconfiguration/autoreconfiguration.go
@@ -18,6 +18,7 @@ package autoreconfiguration
 
 import (
 	"path/filepath"
+	"regexp"
 
 	"github.com/cloudfoundry/libcfbuildpack/build"
 	"github.com/cloudfoundry/libcfbuildpack/helper"
@@ -46,10 +47,17 @@ func (c AutoReconfiguration) Contribute() error {
 	}, layers.Launch)
 }
 
-// NewAutoReconfiguration creates a new AutoReconfiguration instance.
+// NewAutoReconfiguration creates a new AutoReconfiguration instance. OK is true if
+// a spring core jar is found in the application.
 func NewAutoReconfiguration(build build.Build) (AutoReconfiguration, bool, error) {
 	bp, ok := build.BuildPlan[Dependency]
 	if !ok {
+		return AutoReconfiguration{}, false, nil
+	}
+
+	if exist, err := helper.HasFile(build.Application.Root, regexp.MustCompile(filepath.Join(".*", ".*spring-core.*\\.jar"))); err != nil {
+		return AutoReconfiguration{}, false, err
+	} else if !exist {
 		return AutoReconfiguration{}, false, nil
 	}
 

--- a/autoreconfiguration/autoreconfiguration_test.go
+++ b/autoreconfiguration/autoreconfiguration_test.go
@@ -39,24 +39,36 @@ func TestAutoReconfiguration(t *testing.T) {
 			f = test.NewBuildFactory(t)
 		})
 
-		it("returns true if build plan does exist", func() {
+		it("returns false if build plan does not exist", func() {
+			test.TouchFile(t, filepath.Join(f.Build.Application.Root, "spring-core-1.2.3.RELEASE.jar"))
+
+			_, ok, err := autoreconfiguration.NewAutoReconfiguration(f.Build)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(ok).To(BeFalse())
+		})
+
+		it("returns false if spring core jar file does not exist", func() {
+			f.AddBuildPlan(autoreconfiguration.Dependency, buildplan.Dependency{})
+
+			_, ok, err := autoreconfiguration.NewAutoReconfiguration(f.Build)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(ok).To(BeFalse())
+		})
+
+		it("returns true if build plan and spring core jar file both exist", func() {
 			f.AddBuildPlan(autoreconfiguration.Dependency, buildplan.Dependency{})
 			f.AddDependency(autoreconfiguration.Dependency, filepath.Join("testdata", "stub-auto-reconfiguration.jar"))
+			test.TouchFile(t, filepath.Join(f.Build.Application.Root, "spring-core-1.2.3.RELEASE.jar"))
 
 			_, ok, err := autoreconfiguration.NewAutoReconfiguration(f.Build)
 			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(ok).To(BeTrue())
 		})
 
-		it("returns false if build plan does not exist", func() {
-			_, ok, err := autoreconfiguration.NewAutoReconfiguration(f.Build)
-			g.Expect(err).NotTo(HaveOccurred())
-			g.Expect(ok).To(BeFalse())
-		})
-
 		it("contributes jar", func() {
 			f.AddBuildPlan(autoreconfiguration.Dependency, buildplan.Dependency{})
 			f.AddDependency(autoreconfiguration.Dependency, filepath.Join("testdata", "stub-auto-reconfiguration.jar"))
+			test.TouchFile(t, filepath.Join(f.Build.Application.Root, "test", "spring-core-1.2.3.RELEASE.jar"))
 
 			y, ok, err := autoreconfiguration.NewAutoReconfiguration(f.Build)
 			g.Expect(err).NotTo(HaveOccurred())

--- a/detect/main.go
+++ b/detect/main.go
@@ -19,12 +19,9 @@ package main
 import (
 	"fmt"
 	"os"
-	"path/filepath"
-	"regexp"
 
 	"github.com/buildpack/libbuildpack/buildplan"
 	"github.com/cloudfoundry/libcfbuildpack/detect"
-	"github.com/cloudfoundry/libcfbuildpack/helper"
 	"github.com/cloudfoundry/spring-auto-reconfiguration-cnb/autoreconfiguration"
 )
 
@@ -44,11 +41,5 @@ func main() {
 }
 
 func d(detect detect.Detect) (int, error) {
-	if exist, err := helper.HasFile(detect.Application.Root, regexp.MustCompile(filepath.Join(".*", ".*spring-core.*\\.jar"))); err != nil {
-		return detect.Error(102), err
-	} else if exist {
-		return detect.Pass(buildplan.BuildPlan{autoreconfiguration.Dependency: detect.BuildPlan[autoreconfiguration.Dependency]})
-	}
-
-	return detect.Fail(), nil
+	return detect.Pass(buildplan.BuildPlan{autoreconfiguration.Dependency: detect.BuildPlan[autoreconfiguration.Dependency]})
 }

--- a/detect/main_test.go
+++ b/detect/main_test.go
@@ -17,13 +17,10 @@
 package main
 
 import (
-	"path/filepath"
 	"testing"
 
-	"github.com/buildpack/libbuildpack/buildplan"
 	"github.com/buildpack/libbuildpack/detect"
 	"github.com/cloudfoundry/libcfbuildpack/test"
-	"github.com/cloudfoundry/spring-auto-reconfiguration-cnb/autoreconfiguration"
 	. "github.com/onsi/gomega"
 	"github.com/sclevine/spec"
 	"github.com/sclevine/spec/report"
@@ -40,17 +37,8 @@ func TestDetect(t *testing.T) {
 			f = test.NewDetectFactory(t)
 		})
 
-		it("passes with a spring core jar present", func() {
-			test.TouchFile(t, filepath.Join(f.Detect.Application.Root, "spring-core-1.2.3.RELEASE.jar"))
-
+		it("always passes", func() {
 			g.Expect(d(f.Detect)).To(Equal(detect.PassStatusCode))
-			g.Expect(f.Output).To(Equal(buildplan.BuildPlan{
-				autoreconfiguration.Dependency: buildplan.Dependency{},
-			}))
-		})
-
-		it("fails with no spring core jar present", func() {
-			g.Expect(d(f.Detect)).To(Equal(detect.FailStatusCode))
 		})
 	}, spec.Report(report.Terminal{}))
 }


### PR DESCRIPTION
Previously detection would fail if the user tried to push an application from source, as
no spring-core jar would be present in the source. This commit moves the search for the
jar from detect (which now only looks for a java app) to build, where the compiled app
is present.

Signed-off-by: Paul Harris <pharris@pivotal.io>